### PR TITLE
Fix admin password failure closes dialog

### DIFF
--- a/ui/admin.py
+++ b/ui/admin.py
@@ -17,6 +17,7 @@ class AdminDialog(QDialog):
         self.setModal(True)
 
         if not self._check_password():
+            self.reject()
             return
 
         self._setup_ui()


### PR DESCRIPTION
## Summary
- call `self.reject()` in `AdminDialog.__init__` when authentication fails

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6860f7b05c90832abcc49b90f7f4e6b3