### PR TITLE
Implement HOTFIX-002

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,7 +6,8 @@ This document explains the changes made to the latent-self project.
 
 The latent directions have been updated to use the InterFaceGAN vectors for age, gender, and smile. The new vectors are stored in `latent_directions.npz`.
 
-The `directions.yaml` file contains the default `max_magnitude` for each vector.
+The `directions.yaml` file contains metadata for each direction, including a
+human‑friendly `label` and the default `max_magnitude`.
 
 ## Hot-keys
 

--- a/data/directions.yaml
+++ b/data/directions.yaml
@@ -1,8 +1,12 @@
 age:
+  label: Age
   max_magnitude: 3.0
 gender:
+  label: Gender
   max_magnitude: 3.0
 smile:
+  label: Smile
   max_magnitude: 3.0
 species:
+  label: Species
   max_magnitude: 3.0

--- a/latent_self.py
+++ b/latent_self.py
@@ -479,6 +479,10 @@ class LatentSelf:
         self.max_magnitudes = {
             k.upper(): v['max_magnitude'] for k, v in self.config.directions_data.items()
         }
+        self.direction_labels = {
+            k.upper(): v.get('label', k.capitalize()) for k, v in self.config.directions_data.items()
+        }
+        self._hud_values = {k: None for k in self.direction_labels}
 
     # ------------------------------------------------------------------
     # Latent utilities
@@ -659,7 +663,10 @@ class LatentSelf:
                             value = current_magnitude
                         else:
                             value = 0.0
-                        ui_elements.label.setText(f"{name}: {value:+.1f}")
+                        if self._hud_values.get(name.upper()) != value:
+                            self._hud_values[name.upper()] = value
+                            label = self.direction_labels.get(name.upper(), name.capitalize())
+                            ui_elements.label.setText(f"{label}: {value:+.1f}")
 
                 frame_emitter.emit(_numpy_to_qimage(out_frame))
                 QThread.msleep(int(1000 / self.config.data['fps']))

--- a/tasks.yml
+++ b/tasks.yml
@@ -191,7 +191,7 @@ PHASE_I_HOTFIXES:
     desc: Move per‑direction max_magnitude and labels into directions.yaml; HUD reads once instead of updating every frame.
     tags: [refactor, config, ui]
     priority: P0
-    status: todo
+    status: done
 
   - id: HOTFIX-003
     title: Catch Mediapipe runtime exceptions


### PR DESCRIPTION
## Summary
- add labels to `directions.yaml`
- expose `direction_labels` and `_hud_values` via config
- update HUD updates to use labels and avoid repeated refreshes
- document new direction metadata
- mark HOTFIX-002 complete in `tasks.yml`

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6860fa5d5cd0832aa5f78a1bbe8c35ba