### PR TITLE
Implement import guards and tidy fallback handling

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -265,12 +265,12 @@ PHASE_K_AUDIT:
   - id: AUDIT-001
     title: Reorganise imports & fallback handling
     desc: |
-      • Remove unused imports (shutil, socket, duplicate logging).  
-      • Promote all critical imports to top of file or wrap in lazy-loader with explicit error message (pSp, mediapipe).  
+      • Remove unused imports (shutil, socket, duplicate logging).
+      • Promote all critical imports to top of file or wrap in lazy-loader with explicit error message (pSp, mediapipe).
       • Add try/except ImportError guard for optional extras.
     tags: [bugfix, imports]
     priority: P0
-    status: todo
+    status: done
 
   - id: AUDIT-002
     title: Thread-safety for shared state


### PR DESCRIPTION
## Summary
- reorganise imports and add explicit mediapipe guard
- copy default config/directions without shutil
- use `platform.node()` for MQTT device id
- mark AUDIT-001 complete in tasks

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6860ff62a468832a8ca29dd2a07c8ca7