### PR TITLE
Fix thread safety for camera and direction handling

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -290,7 +290,7 @@ PHASE_K_AUDIT:
       • Verify camera open/close is called only from one thread.
     tags: [bugfix, threading]
     priority: P0
-    status: todo
+    status: done
 
   - id: AUDIT-003
     title: Robust error & resource management

--- a/ui/fullscreen.py
+++ b/ui/fullscreen.py
@@ -32,7 +32,7 @@ class MirrorWindow(QMainWindow):
         elif event.key() in (Qt.Key.Key_Q, Qt.Key.Key_Escape):
             self.close()
         elif event.key() == Qt.Key.Key_S:
-            self.app.active_direction = "SPECIES"
+            self.app.video.enqueue_direction("SPECIES")
 
     def show_fullscreen(self) -> None:
         """Show the window in fullscreen mode and hide the cursor."""


### PR DESCRIPTION
## Summary
- guard shared state with locks in `VideoProcessor`
- open and close the webcam only from the worker thread
- add a command queue for cross-thread direction updates
- update Qt UI to use new queue
- mark AUDIT-002 task as done

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6861fc36c534832a9d148f2973b7d494