### PR TITLE
Add docstrings and diagram, remove binary

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -34,6 +34,14 @@ The application is primarily written in Python and leverages the following key l
 - `ui/fullscreen.py`: Implements the main mirror display window.
 - `ui/admin.py`: Provides an administrative interface for adjusting application parameters.
 
+### Diagram
+
+The following PlantUML diagram illustrates the high-level architecture:
+
+```plantuml
+!include docs/architecture.puml
+```
+
 ## Configuration
 
 Default configuration settings are located in `data/config.yaml`. On the first run, this file is copied to a user-specific configuration directory (e.g., `~/.latent_self/config.yaml` on Linux/macOS, or `C:\Users\<User>\AppData\Local\LatentSelf\LatentSelf\config.yaml` on Windows).

--- a/config_schema.py
+++ b/config_schema.py
@@ -1,9 +1,13 @@
+"""Configuration schema models used for validation and CLI overrides."""
+
 from __future__ import annotations
 
 from pydantic import BaseModel, BaseSettings, Field
 from typing import Dict
 
 class BlendWeights(BaseModel):
+    """Weights for each morphing direction used when blending."""
+
     age: float = 0.4
     gender: float = 0.3
     ethnicity: float = 0.5
@@ -11,6 +15,8 @@ class BlendWeights(BaseModel):
     smile: float | None = None
 
 class MQTTConfig(BaseModel):
+    """Settings for optional MQTT heartbeat publishing."""
+
     enabled: bool = False
     broker: str = "localhost"
     port: int = 1883
@@ -19,6 +25,8 @@ class MQTTConfig(BaseModel):
     heartbeat_interval: int = 5
 
 class AppConfig(BaseModel):
+    """Primary application configuration model."""
+
     cycle_duration: float = 12.0
     blend_weights: BlendWeights = Field(default_factory=BlendWeights)
     fps: int = 15
@@ -32,16 +40,23 @@ class AppConfig(BaseModel):
     idle_fade_frames: int | None = None
 
 class DirectionEntry(BaseModel):
+    """Metadata for a single latent direction."""
+
     label: str
     max_magnitude: float = 3.0
 
 class DirectionsConfig(BaseModel):
+    """Container for multiple DirectionEntry objects."""
+
     __root__: Dict[str, DirectionEntry]
 
     def to_dict(self) -> Dict[str, Dict[str, float | str]]:
+        """Return plain dictionary representation."""
         return {k: v.dict() for k, v in self.__root__.items()}
 
 class CLIOverrides(BaseSettings):
+    """Command-line arguments mapped to config values."""
+
     cycle_duration: float | None = None
     blend_age: float | None = None
     blend_gender: float | None = None

--- a/directions.py
+++ b/directions.py
@@ -1,3 +1,5 @@
+"""Registry of supported latent directions and hotkeys."""
+
 from __future__ import annotations
 
 from enum import Enum
@@ -15,6 +17,8 @@ class Direction(str, Enum):
 
     @classmethod
     def from_str(cls, name: str) -> "Direction":
+        """Look up a direction by name (case-insensitive)."""
+
         try:
             return cls[name.upper()]
         except KeyError as exc:
@@ -22,10 +26,14 @@ class Direction(str, Enum):
 
     @classmethod
     def from_key(cls, key: str) -> Optional["Direction"]:
+        """Return the direction bound to a keyboard shortcut."""
+
         return HOTKEYS.get(key.lower())
 
     @classmethod
     def key(cls, direction: "Direction") -> str:
+        """Return the hotkey associated with ``direction``."""
+
         for k, v in HOTKEYS.items():
             if v is direction:
                 return k

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -1,0 +1,23 @@
+@startuml
+!define AWSPUML https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/v14.0/LATEST/AWSPUML
+skinparam backgroundColor transparent
+
+actor User
+component "LatentSelf" as LS {
+  component ConfigManager
+  component ModelManager
+  component VideoProcessor
+  component TelemetryClient
+  component MemoryMonitor
+  component UI
+}
+
+User --> UI
+UI --> LS
+LS --> ConfigManager
+LS --> ModelManager
+LS --> VideoProcessor
+LS --> TelemetryClient
+LS --> MemoryMonitor
+VideoProcessor --> ModelManager
+@enduml

--- a/latent_self.py
+++ b/latent_self.py
@@ -63,6 +63,7 @@ except ImportError as exc:  # pragma: no cover - runtime fail hard
 
 @dataclass
 class DirectionUI:
+    """Helper structure binding a UI slider and label to a direction."""
     name: str
     slider: "QSlider"
     label: "QLabel"
@@ -89,6 +90,7 @@ except ImportError:
 
 
 class LatentSelf:
+    """Orchestrates models, video processing and UI components."""
     def __init__(
         self,
         config: ConfigManager,

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,3 +1,5 @@
+"""Logging utilities for console and kiosk modes."""
+
 import json
 import logging
 from logging import LogRecord

--- a/tasks.yml
+++ b/tasks.yml
@@ -399,4 +399,4 @@ PHASE_K_AUDIT:
     desc: Fill missing docstrings, add architecture diagram (PlantUML) to docs site.
     tags: [docs]
     priority: P3
-    status: todo
+    status: done


### PR DESCRIPTION
## Summary
- document config schema and latent direction utilities
- clarify helper dataclasses and service modules
- show PlantUML architecture diagram in docs
- mark audit task as done
- remove unused binary diagram

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6862199f7744832ab3a36d724d32d769