### PR TITLE
Fix CI workflow to use artifact action v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pytest -q
       - run: mkdocs build --strict
       - run: pyinstaller latent_self.spec
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: latent-self-${{ matrix.os }}
           path: dist/


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to `v4`

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q` *(fails: ModuleNotFoundError for yaml and appdirs)*

------
https://chatgpt.com/codex/tasks/task_e_68624c47a0d8832aa3f622bc26745476