### PR TITLE
Fix MQTT attribute for optional dependency

### DIFF
--- a/services.py
+++ b/services.py
@@ -41,6 +41,7 @@ try:
     import paho.mqtt.client as mqtt
     MQTT_AVAILABLE = True
 except ImportError:  # pragma: no cover - optional feature
+    mqtt = None
     MQTT_AVAILABLE = False
 
 


### PR DESCRIPTION
## Summary
- set `mqtt` attribute to `None` when paho-mqtt isn't installed

## Testing
- `pytest -q`
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6862547be9f4832a95ec851f31909a2f