### PR TITLE
Add emotion hotkeys

### DIFF
--- a/data/directions.yaml
+++ b/data/directions.yaml
@@ -13,3 +13,21 @@ species:
 beauty:
   label: Beauty
   max_magnitude: 2.5
+happy:
+  label: Happy
+  max_magnitude: 3.0
+angry:
+  label: Angry
+  max_magnitude: 3.0
+sad:
+  label: Sad
+  max_magnitude: 3.0
+fear:
+  label: Fear
+  max_magnitude: 3.0
+disgust:
+  label: Disgust
+  max_magnitude: 3.0
+surprise:
+  label: Surprise
+  max_magnitude: 3.0

--- a/directions.py
+++ b/directions.py
@@ -14,6 +14,12 @@ class Direction(str, Enum):
     ETHNICITY = "ETHNICITY"
     SPECIES = "SPECIES"
     BEAUTY = "BEAUTY"
+    HAPPY = "HAPPY"
+    ANGRY = "ANGRY"
+    SAD = "SAD"
+    FEAR = "FEAR"
+    DISGUST = "DISGUST"
+    SURPRISE = "SURPRISE"
     BLEND = "BLEND"
 
     @classmethod
@@ -48,5 +54,11 @@ HOTKEYS: dict[str, Direction] = {
     "e": Direction.ETHNICITY,
     "s": Direction.SPECIES,
     "u": Direction.BEAUTY,
+    "1": Direction.HAPPY,
+    "2": Direction.ANGRY,
+    "3": Direction.SAD,
+    "4": Direction.FEAR,
+    "5": Direction.DISGUST,
+    "6": Direction.SURPRISE,
     "b": Direction.BLEND,
 }

--- a/latent_self.py
+++ b/latent_self.py
@@ -160,7 +160,7 @@ class LatentSelf:
         """Display output using OpenCV windows."""
         logging.info(
             "Using cv2 UI. Controls: [q]uit | [y]age | [g]ender | [h]smile | "
-            "[s]pecies | [u]beauty | [b]lend"
+            "[s]pecies | [u]beauty | [1]happy | [2]angry | [3]sad | [4]fear | [5]disgust | [6]surprise | [b]blend"
         )
         self.video.start()
         self.video.join()


### PR DESCRIPTION
## Summary
- extend directions.yaml with emotion entries
- map six emotion directions and hotkeys
- update OpenCV help text
- keep emotion tasks open
- revert changes to latent_directions.npz binary

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6862568b1444832a9bfeaa3b63bf786b