### PR TITLE
Add pydantic-settings dependency

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -26,6 +26,7 @@ The application is primarily written in Python and leverages the following key l
 - **Mediapipe**: Used for robust face and eye tracking to ensure accurate alignment for morphing.
 - **PyInstaller**: For packaging the application into a standalone executable.
 - **paho-mqtt**: (Optional) For sending heartbeat signals to an MQTT broker for remote monitoring.
+- **pydantic-settings**: For typed configuration management and CLI overrides.
 
 ### Core Components
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Latent Self is an interactive art installation that uses a webcam to capture a u
 *   Fullscreen kiosk mode (`--kiosk`)
 *   Admin panel for on-site configuration
 *   MQTT heartbeat for remote monitoring
+*   Typed configuration via **pydantic-settings**
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ PyQt6
 paho-mqtt
 Werkzeug
 pydantic
+pydantic-settings
 psutil

--- a/tasks.yml
+++ b/tasks.yml
@@ -407,7 +407,7 @@ PHASE_L_REVIEW:
     desc: Include pydantic-settings in requirements.txt and update docs.
     tags: [dependency, config]
     priority: P2
-    status: todo
+    status: done
 
   - id: REVIEW-002
     title: Migrate Pydantic dict() calls


### PR DESCRIPTION
## Summary
- include `pydantic-settings` in requirements
- mention typed configuration in README
- document `pydantic-settings` in the docs
- mark REVIEW-001 as done in tasks

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686269d91ecc832a927bc56b2546e637