### PR TITLE
Fix pydantic dump calls

### DIFF
--- a/services.py
+++ b/services.py
@@ -121,7 +121,7 @@ class ConfigManager:
         if overrides.max_gpu_mem_gb is not None:
             self.data["max_gpu_mem_gb"] = overrides.max_gpu_mem_gb
         try:
-            self.data = AppConfig(**self.data).dict()
+            self.data = AppConfig(**self.data).model_dump()
         except ValidationError as e:
             raise RuntimeError(f"Invalid configuration after CLI overrides: {e}")
 
@@ -131,7 +131,7 @@ class ConfigManager:
             with self.config_path.open("r") as f:
                 raw_cfg = yaml.safe_load(f) or {}
             cfg = AppConfig(**raw_cfg)
-            self.data = cfg.dict()
+            self.data = cfg.model_dump()
         except (yaml.YAMLError, ValidationError) as e:
             raise RuntimeError(f"Invalid config.yaml: {e}")
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -414,7 +414,7 @@ PHASE_L_REVIEW:
     desc: Replace deprecated .dict() usages with .model_dump() in services.py.
     tags: [refactor, pydantic]
     priority: P3
-    status: todo
+    status: done
 
   - id: REVIEW-003
     title: Fix truncated README usage section


### PR DESCRIPTION
## Summary
- use `model_dump()` when dumping pydantic configs in `services.py`
- mark REVIEW-002 task as done

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686a4164c530832aa1e3c8cc8febb440