### PR TITLE
Load canonical eye config

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -55,6 +55,7 @@ Key configuration parameters include:
 - `blend_weights`: Dictionary controlling the influence of different latent directions (age, gender, ethnicity, species) when in blended morphing mode.
 - `fps`: Target frames per second for the display.
 - `tracker_alpha`: Smoothing factor for the eye-tracking algorithm.
+- `canonical_eyes`: Reference eye coordinates used for face alignment.
 - `admin_password_hash`: Hashed password for accessing the admin panel.
 - `mqtt`: MQTT broker settings for optional remote monitoring.
 

--- a/config_schema.py
+++ b/config_schema.py
@@ -32,6 +32,9 @@ class AppConfig(BaseModel):
     blend_weights: BlendWeights = Field(default_factory=BlendWeights)
     fps: int = 15
     tracker_alpha: float = 0.4
+    canonical_eyes: list[list[float]] = Field(
+        default_factory=lambda: [[80.0, 100.0], [176.0, 100.0]]
+    )
     admin_password_hash: str = ""
     mqtt: MQTTConfig = Field(default_factory=MQTTConfig)
     idle_seconds: int = 3

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -14,7 +14,10 @@ blend_weights:
 # -- Performance --
 fps: 15  # Target frames per second
 tracker_alpha: 0.4  # Smoothing factor for eye tracking (0.0 - 1.0)
-max_cpu_mem_mb: 
+canonical_eyes:
+  - [80.0, 100.0]
+  - [176.0, 100.0]
+max_cpu_mem_mb:
 max_gpu_mem_gb: 
 memory_check_interval: 10
 

--- a/services.py
+++ b/services.py
@@ -390,7 +390,10 @@ class VideoProcessor:
 
         self.tracker = _EyeTracker(alpha=self.config.data.get("tracker_alpha", 0.4))
         self.tracker_lock = Lock()
-        self._canonical = np.array([[80.0, 100.0], [176.0, 100.0]], dtype=np.float32)
+        self._canonical = np.array(
+            self.config.data.get("canonical_eyes", [[80.0, 100.0], [176.0, 100.0]]),
+            dtype=np.float32,
+        )
         self.stop_event = Event()
         self._processing_thread: Thread | None = None
         self.REENCODE_INTERVAL_S = 10.0
@@ -411,6 +414,10 @@ class VideoProcessor:
         self._hud_values = {k: None for k in self.direction_labels}
         with self.tracker_lock:
             self.tracker.alpha = self.config.data.get("tracker_alpha", 0.4)
+        self._canonical = np.array(
+            self.config.data.get("canonical_eyes", [[80.0, 100.0], [176.0, 100.0]]),
+            dtype=np.float32,
+        )
 
     # ------------------------------------------------------------------
     # Core latent helpers

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -11,6 +11,7 @@ def test_app_config_valid():
     config = AppConfig(**data)
     assert config.cycle_duration > 0
     assert 'age' in config.blend_weights.model_dump()
+    assert len(config.canonical_eyes) == 2
 
 
 def test_app_config_invalid_cycle_duration():


### PR DESCRIPTION
## Summary
- add `canonical_eyes` to AppConfig
- update default `config.yaml`
- load canonical eye values in `VideoProcessor`
- document canonical eyes in configuration docs
- test config schema covers new field

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4354b664832a8e016d7e3ebe1ca2