### PR TITLE
Add password hash generator script

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -57,6 +57,8 @@ Key configuration parameters include:
 - `tracker_alpha`: Smoothing factor for the eye-tracking algorithm.
 - `canonical_eyes`: Reference eye coordinates used for face alignment.
 - `admin_password_hash`: Hashed password for accessing the admin panel.
+- To generate a new hash run `python scripts/generate_password_hash.py` and
+  paste the output into `admin_password_hash` in your config file.
 - `mqtt`: MQTT broker settings for optional remote monitoring.
 
 ## Extending Functionality

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ This project requires the following model weights:
 
 Place these files in a `models` directory in the project root.
 
+## Admin Password
+
+Generate a hashed password for the admin panel:
+
+```bash
+python scripts/generate_password_hash.py mysecret
+```
+
+Copy the printed hash into your `config.yaml` under the
+`admin_password_hash` field.
+
 ## Usage
 
 ```bash

--- a/scripts/generate_password_hash.py
+++ b/scripts/generate_password_hash.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Utility to generate a WerkZeug password hash for the admin panel."""
+from __future__ import annotations
+
+import argparse
+import getpass
+from werkzeug.security import generate_password_hash
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a password hash for `admin_password_hash`"
+    )
+    parser.add_argument(
+        "password",
+        nargs="?",
+        help="Plaintext password. If omitted you will be prompted",
+    )
+    args = parser.parse_args()
+
+    password = args.password or getpass.getpass("Password: ")
+    print(generate_password_hash(password))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_password_hash.py` utility
- document generating admin password hash in DOCS and README

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686a46ad96e0832a84261bb41b5b5178