### PR TITLE
Add user manual

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -12,6 +12,7 @@ This document provides detailed information about the Latent Self application, i
   - [Customizing the UI](#customizing-the-ui)
 - [Troubleshooting](#troubleshooting)
 
+- [User Manual](docs/user_manual.md)
 ## Project Overview
 
 Latent Self is an interactive art installation that uses real-time face morphing. It captures a user's face via webcam and applies transformations based on pre-trained StyleGAN and e4e models. The transformed image is displayed, creating a dynamic "altered reflection."
@@ -91,3 +92,5 @@ To add a new morphing direction (e.g., "happiness"), follow these steps:
 - **Model Loading Errors**: Verify that all required model weights (`.pkl`, `.pt`, `.npz`) are present in the `models/` directory and are not corrupted.
 - **PyQt6 Issues**: If the Qt UI fails to launch, ensure PyQt6 is correctly installed (`pip install PyQt6`).
 - **Performance Issues**: Real-time performance is heavily dependent on GPU availability. Ensure CUDA is properly configured if you intend to use it (`--cuda` flag).
+
+For step-by-step setup see the [User Manual](docs/user_manual.md).

--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ For additional options run:
 ```bash
 python latent_self.py -h
 ```
+
+See the [User Manual](docs/user_manual.md) for detailed setup and troubleshooting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,4 @@
 Welcome to the Latent Self documentation site.
 
 - [Architecture](architecture.puml)
+- [User Manual](user_manual.md)

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,0 +1,50 @@
+# User Manual
+
+This guide walks you through installing Latent Self, adjusting its configuration and resolving common issues.
+
+## Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/your-username/latent-self.git
+   cd latent-self
+   ```
+2. Install the Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Download the required model weights (StyleGAN generator, e4e encoder and `latent_directions.npz`) and place them inside the `models/` directory.
+4. (Optional) Build a standalone executable with PyInstaller:
+   ```bash
+   pyinstaller latent_self.spec
+   ```
+
+## Configuration
+
+When run for the first time, `data/config.yaml` is copied to a user specific directory such as `~/.latent_self/` on Linux/macOS or `%APPDATA%\LatentSelf\` on Windows. The admin panel writes back to this file whenever you adjust settings.
+
+Key options include:
+
+- `cycle_duration` – seconds for a full morph cycle.
+- `blend_weights` – relative strength of each latent direction.
+- `fps` – target frames per second.
+- `admin_password_hash` – hashed password generated via `scripts/generate_password_hash.py`.
+- `mqtt` – optional heartbeat settings.
+
+You can also edit the YAML file directly or override values via CLI arguments.
+
+## Common Issues
+
+**Camera not detected**
+: Ensure no other application is using the webcam and that the correct `camera_index` is set.
+
+**Missing model weights**
+: Double‑check that all `.pkl`, `.pt` and `.npz` files are present in `models/`.
+
+**Qt UI fails to start**
+: Confirm that PyQt6 is installed. Use `pip install PyQt6` if necessary.
+
+**Poor performance**
+: Running on CPU can be slow. Install CUDA drivers and use `--cuda` to enable GPU acceleration.
+
+For additional help see the [project documentation](DOCS.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,5 +5,6 @@ nav:
   - Home: index.md
   - Architecture: architecture.puml
   - Deployment: deployment.md
+  - User Manual: user_manual.md
 
 docs_dir: docs

--- a/tasks.yml
+++ b/tasks.yml
@@ -134,6 +134,13 @@ PHASE_F_DOCS_AGENTS:
     priority: P1
     status: done
 
+  - id: DOCS-007
+    title: Add user manual
+    desc: Create docs/user_manual.md with installation, configuration and common issues.
+    tags: [docs]
+    priority: P2
+    status: done
+
 PHASE_G_TESTS_AGENTS:
   - id: TEST-001
     title: Unit tests for latent_offset


### PR DESCRIPTION
## Summary
- document installation, configuration and common issues in new `docs/user_manual.md`
- link the user manual from README and DOCS
- expose user manual in MkDocs navigation and docs index
- track work in `tasks.yml`

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686a474c08d4832a8d1616f591ce5929