### PR TITLE
Update CONTRIBUTING test setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,16 @@ Thank you for considering contributing! We welcome pull requests and issues.
 3. Run `python -m py_compile latent_self.py ui/*.py` before committing.
 4. Execute tests with `pytest`.
 
+## Test Environment Setup
+To run the test suite locally:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pytest
+```
+
 ## Code Style
 - Follow [PEP8](https://peps.python.org/pep-0008/) and type-hint all public APIs.
 - Use Google-style docstrings.

--- a/tasks.yml
+++ b/tasks.yml
@@ -428,4 +428,4 @@ PHASE_L_REVIEW:
     desc: Explain installing dependencies and running pytest in CONTRIBUTING.md.
     tags: [docs, tests]
     priority: P3
-    status: todo
+    status: done


### PR DESCRIPTION
## Summary
- document how to create a virtual environment, install requirements and run tests
- mark REVIEW-004 as done in tasks list

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a4624640c832a8c7be2b264e8220e