### PR TITLE
Fix pydantic dump usage

### DIFF
--- a/services.py
+++ b/services.py
@@ -143,7 +143,7 @@ class ConfigManager:
             with self.directions_path.open("r") as f:
                 raw_dir = yaml.safe_load(f) or {}
             dirs = DirectionsConfig(__root__=raw_dir)
-            self.directions_data = dirs.to_dict()
+            self.directions_data = dirs.model_dump()
         except (yaml.YAMLError, ValidationError) as e:
             raise RuntimeError(f"Invalid directions.yaml: {e}")
 


### PR DESCRIPTION
## Summary
- update ConfigManager to dump directions config with `model_dump`

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6511e9ac832a9db425be42c5b201