### PR TITLE
Move eye tracking coords to config

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -56,7 +56,7 @@ Key configuration parameters include:
 - `blend_weights`: Dictionary controlling the influence of different latent directions (age, gender, ethnicity, species) when in blended morphing mode.
 - `fps`: Target frames per second for the display.
 - `tracker_alpha`: Smoothing factor for the eye-tracking algorithm.
-- `eye_canonical`: Reference eye coordinates used for face alignment.
+- `eye_tracker.left_eye`/`right_eye`: Reference eye coordinates used for face alignment.
 - `admin_password_hash`: Hashed password for accessing the admin panel.
 - To generate a new hash run `python scripts/generate_password_hash.py` and
   paste the output into `admin_password_hash` in your config file.

--- a/config_schema.py
+++ b/config_schema.py
@@ -33,6 +33,13 @@ class MQTTConfig(BaseModel):
     client_cert: str | None = None
     client_key: str | None = None
 
+class EyeTrackerConfig(BaseModel):
+    """Configuration for eye tracking alignment."""
+
+    left_eye: list[float] = Field(default_factory=lambda: [80.0, 100.0])
+    right_eye: list[float] = Field(default_factory=lambda: [176.0, 100.0])
+
+
 class AppConfig(BaseModel):
     """Primary application configuration model."""
 
@@ -40,9 +47,7 @@ class AppConfig(BaseModel):
     blend_weights: BlendWeights = Field(default_factory=BlendWeights)
     fps: int = 15
     tracker_alpha: float = 0.4
-    eye_canonical: list[list[float]] = Field(
-        default_factory=lambda: [[80.0, 100.0], [176.0, 100.0]]
-    )
+    eye_tracker: EyeTrackerConfig = Field(default_factory=EyeTrackerConfig)
     admin_password_hash: str = ""
     mqtt: MQTTConfig = Field(default_factory=MQTTConfig)
     idle_seconds: int = 3

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -15,9 +15,9 @@ active_emotion: HAPPY
 # -- Performance --
 fps: 15  # Target frames per second
 tracker_alpha: 0.4  # Smoothing factor for eye tracking (0.0 - 1.0)
-eye_canonical:
-  - [80.0, 100.0]
-  - [176.0, 100.0]
+eye_tracker:
+  left_eye: [80.0, 100.0]
+  right_eye: [176.0, 100.0]
 max_cpu_mem_mb:
 max_gpu_mem_gb:
 memory_check_interval: 10

--- a/services.py
+++ b/services.py
@@ -412,9 +412,14 @@ class VideoProcessor:
         self.cap: cv2.VideoCapture | None = None
         self.camera_available = False
 
+        eye_cfg = self.config.data.get("eye_tracker", {})
+        canonical = [
+            eye_cfg.get("left_eye", [80.0, 100.0]),
+            eye_cfg.get("right_eye", [176.0, 100.0]),
+        ]
         self.tracker = _EyeTracker(
             alpha=self.config.data.get("tracker_alpha", 0.4),
-            canonical=self.config.data.get("eye_canonical", [[80.0, 100.0], [176.0, 100.0]]),
+            canonical=canonical,
         )
         self.tracker_lock = Lock()
         self.stop_event = Event()
@@ -441,10 +446,12 @@ class VideoProcessor:
         self._hud_values = {k: None for k in self.direction_labels}
         with self.tracker_lock:
             self.tracker.alpha = self.config.data.get("tracker_alpha", 0.4)
-            self.tracker.canonical = np.array(
-                self.config.data.get("eye_canonical", [[80.0, 100.0], [176.0, 100.0]]),
-                dtype=np.float32,
-            )
+            eye_cfg = self.config.data.get("eye_tracker", {})
+            canonical = [
+                eye_cfg.get("left_eye", [80.0, 100.0]),
+                eye_cfg.get("right_eye", [176.0, 100.0]),
+            ]
+            self.tracker.canonical = np.array(canonical, dtype=np.float32)
         self.target_fps = self.config.data.get("fps", 15)
         emotion = self.config.data.get("active_emotion")
         if emotion:

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -11,7 +11,8 @@ def test_app_config_valid():
     config = AppConfig(**data)
     assert config.cycle_duration > 0
     assert 'age' in config.blend_weights.model_dump()
-    assert len(config.eye_canonical) == 2
+    assert len(config.eye_tracker.left_eye) == 2
+    assert len(config.eye_tracker.right_eye) == 2
 
 
 def test_app_config_invalid_cycle_duration():


### PR DESCRIPTION
## Summary
- create `eye_tracker` section with `left_eye` and `right_eye`
- load the canonical eye coordinates from config in `VideoProcessor`
- update schema, docs and tests

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a71dbcf10832ab6c1a61872f56862