### PR TITLE
Fix DirectionsConfig use of model_dump

### DIFF
--- a/services.py
+++ b/services.py
@@ -142,7 +142,7 @@ class ConfigManager:
         try:
             with self.directions_path.open("r") as f:
                 raw_dir = yaml.safe_load(f) or {}
-            dirs = DirectionsConfig(__root__=raw_dir)
+            dirs = DirectionsConfig(root=raw_dir)
             self.directions_data = dirs.model_dump()
         except (yaml.YAMLError, ValidationError) as e:
             raise RuntimeError(f"Invalid directions.yaml: {e}")

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -49,13 +49,6 @@ def test_reload_applies_changes(tmp_path, monkeypatch):
     )
 
     monkeypatch.setattr('appdirs.user_config_dir', lambda *_: str(cfg_dir))
-    # Adapt DirectionsConfig constructor for Pydantic v2
-    orig_dc_init = services.DirectionsConfig.__init__
-    def patched(self, *args, **kwargs):
-        if '__root__' in kwargs:
-            kwargs['root'] = kwargs.pop('__root__')
-        orig_dc_init(self, **kwargs)
-    monkeypatch.setattr(services.DirectionsConfig, '__init__', patched)
     args = make_args(tmp_path)
 
     config = ConfigManager(args, app=None)


### PR DESCRIPTION
## Summary
- use `DirectionsConfig(root=...)` in `ConfigManager.reload`
- remove custom patch from config reload test

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b29fd0d00832a9f633a5647244c49