### PR TITLE
Add cross-platform bundle build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -21,7 +21,7 @@ jobs:
       - run: mypy --install-types --non-interactive .
       - run: pytest -q
       - run: mkdocs build --strict
-      - run: pyinstaller latent_self.spec
+      - run: python scripts/build_bundle.py
       - uses: actions/upload-artifact@v4
         with:
           name: latent-self-${{ matrix.os }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,9 +2,10 @@
 
 This project can run as a kiosk service using **systemd**.
 
-1. Build the application with PyInstaller:
+1. Build the application with PyInstaller. A helper script installs any
+   OS-specific dependencies and runs the build:
    ```bash
-   pyinstaller latent_self.spec
+   python scripts/build_bundle.py
    ```
 2. Copy the service file and executable using the provided install script:
    ```bash
@@ -22,3 +23,7 @@ This project can run as a kiosk service using **systemd**.
 
 The service is configured with `Restart=on-failure` and `WatchdogSec=30s`
 to automatically restart the application if it crashes.
+
+PyInstaller bundles can be produced on Linux, Windows and macOS. The GitHub
+Actions workflow uploads the artifacts from all three platforms under the
+`dist/` directory.

--- a/scripts/build_bundle.py
+++ b/scripts/build_bundle.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Build PyInstaller bundle for the current platform."""
+from __future__ import annotations
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    system = platform.system()
+    if system == "Windows":
+        # pyinstaller on Windows requires pywin32 for proper hooks
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "pywin32"])
+    elif system == "Darwin":
+        # no special dependencies yet, placeholder for future macOS tweaks
+        pass
+
+    spec = ROOT / "latent_self.spec"
+    subprocess.check_call(["pyinstaller", str(spec)])
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.yml
+++ b/tasks.yml
@@ -185,6 +185,13 @@ PHASE_H_CI_CD_AGENTS:
     priority: P1
     status: done
 
+  - id: CI-003
+    title: Cross-platform PyInstaller builds
+    desc: Build Windows and macOS bundles in CI using a helper script.
+    tags: [ci, packaging]
+    priority: P2
+    status: done
+
 PHASE_I_HOTFIXES:
   - id: HOTFIX-001
     title: Deduplicate/guard VideoWorker definitions


### PR DESCRIPTION
## Summary
- add `build_bundle.py` helper
- update CI to build on Windows
- document new script in deployment docs
- track CI automation task

## Testing
- `python -m py_compile latent_self.py ui/*.py scripts/build_bundle.py`

------
https://chatgpt.com/codex/tasks/task_e_686b5ed818c0832a815d9b6ae10e548f