### PR TITLE
Add pre-commit hooks and update docs/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install -r requirements.txt -r requirements-test.txt mypy ruff mkdocs mkdocs-material pyinstaller
-      - run: ruff check .
-      - run: mypy --install-types --non-interactive .
+      - run: pip install -r requirements.txt -r requirements-test.txt mypy ruff black pre-commit mkdocs mkdocs-material pyinstaller
+      - run: pre-commit run --all-files --show-diff-on-failure
       - run: pytest -q
       - run: mkdocs build --strict
       - run: python scripts/build_bundle.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+        language_version: python3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,13 @@ Thank you for considering contributing! We welcome pull requests and issues.
 ## Development Setup
 1. Install Python 3.11 and create a virtual environment.
 2. Install the project dependencies and optional development tools. If you plan to run tests, install `requirements-test.txt` as well.
-3. Run `python -m py_compile latent_self.py ui/*.py` before committing.
-4. Execute tests with `pytest`.
+3. Install `pre-commit` and initialise the git hook:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+4. Run `python -m py_compile latent_self.py ui/*.py` before committing.
+5. Execute tests with `pytest`.
 
 ## Dependency Installation
 Activate your virtual environment and install all Python requirements:
@@ -19,7 +24,7 @@ For linting, type checking, documentation, and packaging you may also install
 the optional development tools used in CI:
 
 ```bash
-pip install mypy ruff mkdocs mkdocs-material pyinstaller
+pip install mypy ruff black pre-commit mkdocs mkdocs-material pyinstaller
 ```
 
 ## Test Dependencies
@@ -31,6 +36,13 @@ pip install -r requirements.txt -r requirements-test.txt
 
 The tools listed above (`mypy`, `ruff`, `mkdocs`, `mkdocs-material`,
 `pyinstaller`) are optional for running the tests but are installed in CI.
+
+## Using pre-commit
+With the hook installed you can run all style and type checks locally:
+
+```bash
+pre-commit run --all-files
+```
 
 ## Running Tests
 To execute the unit tests run from the repository root:
@@ -68,6 +80,7 @@ suite, so they do not need to be installed.
 ## Pull Request Checklist
 - [ ] Tests pass (`pytest`)
 - [ ] `python -m py_compile latent_self.py ui/*.py`
+- [ ] `pre-commit` checks
 - [ ] Updated documentation or comments
 - [ ] Updated `tasks.yml` statuses
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -191,6 +191,12 @@ PHASE_H_CI_CD_AGENTS:
     tags: [ci, packaging]
     priority: P2
     status: done
+  - id: CI-004
+    title: pre-commit hooks
+    desc: Add `.pre-commit-config.yaml`, document installation, and run hooks in CI.
+    tags: [ci, lint]
+    priority: P2
+    status: done
 
 PHASE_I_HOTFIXES:
   - id: HOTFIX-001


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with ruff, mypy and black
- document pre-commit usage in `CONTRIBUTING.md`
- run pre-commit in CI workflow
- track task completion in `tasks.yml`

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q`
- `pre-commit run --files CONTRIBUTING.md .github/workflows/ci.yml tasks.yml .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_686b64d40a50832aa927b678b5ddd5aa