### PR TITLE
Add frame timing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Latent Self is an interactive art installation that uses a webcam to capture a u
 *   Typed configuration via **pydantic-settings**
 *   Demo mode with prerecorded media (`--demo`)
 *   Optional live memory usage readout in the admin panel
+*   Periodic logging of average FPS and latency metrics
 
 ## Installation
 
@@ -96,6 +97,12 @@ python latent_self.py -h
 
 See the [User Manual](USER_MANUAL.md) for detailed setup and the
 [Troubleshooting Guide](docs/troubleshooting.md) for common issues.
+
+## Metrics Output
+
+The application logs average FPS and frame latency every few seconds. Adjust
+`metrics_interval` in `config.yaml` to control how often these statistics are
+emitted.
 
 ![Admin Controls](https://via.placeholder.com/800x400.png?text=Admin+Controls)
 

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -32,6 +32,35 @@ def configure_logging(kiosk: bool, level: int = logging.INFO) -> None:
 from contextlib import contextmanager
 from time import time
 
+
+class FrameTimer:
+    """Aggregate frame processing durations and emit periodic stats."""
+
+    def __init__(self, interval: float = 10.0) -> None:
+        self.interval = interval
+        self._durations: list[float] = []
+        self._last_emit = time()
+
+    def record(self, dur: float) -> None:
+        self._durations.append(dur)
+        now = time()
+        if now - self._last_emit >= self.interval and self._durations:
+            total = sum(self._durations)
+            count = len(self._durations)
+            fps = count / total if total else 0.0
+            avg_latency = total / count
+            logging.info("metrics.fps %.2f metrics.latency %.3fs", fps, avg_latency)
+            self._durations.clear()
+            self._last_emit = now
+
+    @contextmanager
+    def track(self) -> Any:
+        start = time()
+        try:
+            yield
+        finally:
+            self.record(time() - start)
+
 @contextmanager
 def log_timing(label: str) -> Any:
     """Context manager to log timing metrics with DEBUG level."""

--- a/services.py
+++ b/services.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
     from PyQt6.QtGui import QImage
 
 from directions import Direction
-from logging_setup import log_timing
+from logging_setup import FrameTimer, log_timing
 from time import time
 from typing import Any, Dict
 
@@ -483,6 +483,7 @@ class VideoProcessor:
         self.encode_fps = 0.0
         self._skip_next = False
         self.target_fps = self.config.data.get("fps", 15)
+        self.frame_timer = FrameTimer(self.config.data.get("metrics_interval", 10))
 
         self._apply_config()
 
@@ -850,13 +851,16 @@ class VideoProcessor:
                     self.camera_available = False
                     continue
 
-                (
-                    out_frame,
-                    baseline_latent,
-                    last_encode,
-                    idle_frames,
-                    current_magnitude,
-                ) = self._process_frame(frame, baseline_latent, last_encode, idle_frames)
+                with self.frame_timer.track():
+                    (
+                        out_frame,
+                        baseline_latent,
+                        last_encode,
+                        idle_frames,
+                        current_magnitude,
+                    ) = self._process_frame(
+                        frame, baseline_latent, last_encode, idle_frames
+                    )
                 
                 if not self._display_frame(
                     out_frame,

--- a/tasks.yml
+++ b/tasks.yml
@@ -612,3 +612,10 @@ PHASE_T_BACKLOG:
     tags: [core, gpu]
     priority: P3
     status: done
+
+  - id: 211
+    title: Frame metrics logging
+    desc: Log average FPS and processing latency every N seconds.
+    tags: [monitoring, performance]
+    priority: P3
+    status: done

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ import logging
 import pytest
 
 from directions import Direction
-from logging_setup import JsonFormatter, log_timing
+from logging_setup import FrameTimer, JsonFormatter, log_timing
 from latent_self import _validate_args
 
 
@@ -34,6 +34,7 @@ def test_validate_args_valid(tmp_path):
         emotion=None,
         max_cpu_mem=None,
         max_gpu_mem=None,
+        device="auto",
         weights=tmp_path,
     )
     _validate_args(args, parser)
@@ -84,3 +85,11 @@ def test_json_formatter_and_timing():
     record = json.loads(out)
     assert record['message'] == 'hello'
     assert record['level'] == 'info'
+
+
+def test_frame_timer_logs(caplog):
+    timer = FrameTimer(interval=0)
+    caplog.set_level(logging.INFO)
+    with timer.track():
+        pass
+    assert any('metrics.fps' in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- introduce FrameTimer utility for periodic FPS/latency stats
- log metrics in VideoProcessor and expose config interval
- mention metrics in README
- track new task in `tasks.yml`
- test FrameTimer behaviour

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b69aa7a14832a93794291cc184cc1