### PR TITLE
Add macOS and Windows deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,3 +27,59 @@ to automatically restart the application if it crashes.
 PyInstaller bundles can be produced on Linux, Windows and macOS. The GitHub
 Actions workflow uploads the artifacts from all three platforms under the
 `dist/` directory.
+
+## macOS
+
+1. Build the macOS bundle:
+   ```bash
+   python scripts/build_bundle.py
+   ```
+   The resulting `LatentSelf.app` appears inside `dist/`.
+2. Move the app to `/Applications` or another desired path.
+3. Create a LaunchAgent so the kiosk starts on login. Save the following
+   as `~/Library/LaunchAgents/com.latentself.kiosk.plist`:
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+     <dict>
+       <key>Label</key><string>com.latentself.kiosk</string>
+       <key>ProgramArguments</key>
+       <array>
+         <string>/Applications/LatentSelf.app/Contents/MacOS/LatentSelf</string>
+       </array>
+       <key>RunAtLoad</key><true/>
+     </dict>
+   </plist>
+   ```
+   Load it with:
+   ```bash
+   launchctl load -w ~/Library/LaunchAgents/com.latentself.kiosk.plist
+   ```
+4. Alternatively, add the app to your **Login Items** in System Settings.
+
+### macOS Troubleshooting
+- If the app is blocked as "unidentified developer", right-click and choose
+  **Open** or remove the quarantine attribute:
+  `xattr -d com.apple.quarantine /Applications/LatentSelf.app`.
+- Grant webcam permission under **System Settings › Privacy & Security › Camera** if video capture fails.
+
+## Windows
+
+1. Build the Windows executable:
+   ```bash
+   python scripts/build_bundle.py
+   ```
+   The output `LatentSelf.exe` lives in `dist\LatentSelf\`.
+2. To launch at startup create a shortcut in the `shell:startup` folder or
+   install a service with **nssm**:
+   ```powershell
+   nssm install LatentSelf "C:\\path\\to\\LatentSelf.exe"
+   nssm start LatentSelf
+   ```
+
+### Windows Troubleshooting
+- A missing `MSVCP*.dll` message means you need the Microsoft Visual C++
+  Redistributable installed.
+- If the Qt platform plugin "windows" cannot be loaded, ensure all files from
+  the PyInstaller `dist` directory remain together.


### PR DESCRIPTION
## Summary
- expand deployment guide with macOS and Windows instructions
- document LaunchAgent setup and NSSM service creation
- add troubleshooting notes for common platform problems

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686b6bda5c7c832aba26c9515cf12b22