### PR TITLE
Ensure kiosk user stays in sync

### DIFF
--- a/deploy/install_kiosk.sh
+++ b/deploy/install_kiosk.sh
@@ -36,6 +36,8 @@ mkdir -p "$INSTALL_DIR"
 # 2. Copy application files
 cp "$EXECUTABLE_FILE" "$INSTALL_DIR/"
 cp "$SERVICE_FILE" "$SERVICE_PATH"
+# Ensure the service runs as the same kiosk user
+sed -i "s/^User=.*/User=$KIOSK_USER/" "$SERVICE_PATH"
 
 # 3. Set permissions
 chown -R "$KIOSK_USER":"$KIOSK_GROUP" "$INSTALL_DIR"

--- a/deploy/latent_self.service
+++ b/deploy/latent_self.service
@@ -1,4 +1,6 @@
 [Unit]
+# Installed by deploy/install_kiosk.sh.
+# The User= value below must match the KIOSK_USER variable in that script.
 Description=Latent Self Kiosk
 After=network.target
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,6 +14,9 @@ This project can run as a kiosk service using **systemd**.
    This script creates a dedicated `kiosk` user and places the executable in
    `/opt/latent-self/`. It also installs `deploy/latent_self.service` into
    `/etc/systemd/system/`.
+   The script defines a `KIOSK_USER` variable which must match the
+   `User=` value in the service file. The installer automatically updates
+   the file so both remain in sync.
 3. Enable and start the service:
    ```bash
    sudo systemctl daemon-reload


### PR DESCRIPTION
## Summary
- patch service file during installation so `User` matches `$KIOSK_USER`
- add comment in latent_self.service referencing install script
- document kiosk user synchronization in deployment docs

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686b7b9ebe50832a9393475d18c46b5c