### PR TITLE
Add Flask web admin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Werkzeug
 pydantic
 pydantic-settings
 psutil
+Flask

--- a/tasks.yml
+++ b/tasks.yml
@@ -506,7 +506,7 @@ PHASE_T_BACKLOG:
     desc: Implement a simple web server to expose admin settings over the local network.
     tags: [admin, feature]
     priority: P4
-    status: pending
+    status: done
 
   - id: 103
     title: Add API Endpoint for Live Configuration Reload

--- a/web_admin.py
+++ b/web_admin.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Simple Flask-based admin API for reading and updating config."""
+
+from threading import Thread
+from typing import Any
+
+import yaml
+from flask import Flask, request, jsonify, abort
+from werkzeug.security import check_password_hash
+from werkzeug.serving import make_server
+
+from services import ConfigManager
+
+
+class WebAdmin:
+    """Expose config values over HTTP with basic auth."""
+
+    def __init__(self, config: ConfigManager, host: str = "0.0.0.0", port: int = 8001) -> None:
+        self.config = config
+        self.app = Flask(__name__)
+        self._server = make_server(host, port, self.app)
+        self._thread = Thread(target=self._server.serve_forever, daemon=True)
+        self._setup_routes()
+
+    # ------------------------------------------------------------------
+    # Flask route handlers
+    # ------------------------------------------------------------------
+
+    def _auth(self) -> bool:
+        """Return True if request provides valid credentials."""
+        password_hash = self.config.data.get("admin_password_hash", "")
+        if not password_hash:
+            return True
+        auth = request.authorization
+        return bool(auth and check_password_hash(password_hash, auth.password or ""))
+
+    def _setup_routes(self) -> None:
+        @self.app.get("/config")
+        def get_config():
+            if not self._auth():
+                abort(401)
+            return jsonify(self.config.data)
+
+        @self.app.post("/config")
+        def update_config() -> Any:
+            if not self._auth():
+                abort(401)
+            updates = request.get_json(silent=True) or {}
+            with self.config._lock:  # type: ignore[attr-defined]
+                self.config.data.update(updates)
+                with self.config.config_path.open("w") as f:
+                    yaml.dump(self.config.data, f, default_flow_style=False)
+            self.config.reload()
+            return jsonify({"status": "ok"})
+
+    # ------------------------------------------------------------------
+    # Control methods
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+        self._thread.join()


### PR DESCRIPTION
## Summary
- implement password protected web admin via Flask
- allow starting the web server from `latent_self.py`
- mark task 102 complete
- add Flask dependency

## Testing
- `python -m py_compile latent_self.py ui/*.py web_admin.py`

------
https://chatgpt.com/codex/tasks/task_e_686b8303b56c832aa3e5d2559c8ee49b