### PR TITLE
Add Remote Admin API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ python scripts/generate_password_hash.py mysecret
 Copy the printed hash into your `config.yaml` under the
 `admin_password_hash` field.
 
+## Remote Admin API
+
+Start the lightweight HTTP server with `--web-admin` to manage
+configuration over the local network:
+
+```bash
+python latent_self.py --web-admin
+```
+
+The server listens on port **8001** by default and exposes two endpoints:
+
+* `GET /config` – return the current configuration as JSON
+* `POST /config` – update configuration fields (JSON body)
+
+If `admin_password_hash` is set in `config.yaml`, Basic Auth credentials are
+required to access these routes.
+
 ## Usage
 
 ```bash

--- a/tasks.yml
+++ b/tasks.yml
@@ -506,7 +506,7 @@ PHASE_T_BACKLOG:
     desc: Implement a simple web server to expose admin settings over the local network.
     tags: [admin, feature]
     priority: P4
-    status: pending
+    status: done
 
 
   - id: 103


### PR DESCRIPTION
## Summary
- document lightweight web admin server in README
- mark task 102 complete

## Testing
- `python -m py_compile latent_self.py ui/admin.py ui/fullscreen.py ui/xycontrol.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686bb50c8a30832ab8db083982bef45d