### PR TITLE
Add /reload endpoint for web admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ configuration over the local network:
 python latent_self.py --web-admin
 ```
 
-The server listens on port **8001** by default and exposes two endpoints:
+The server listens on port **8001** by default and exposes three endpoints:
 
 * `GET /config` – return the current configuration as JSON
 * `POST /config` – update configuration fields (JSON body)
+* `POST /reload` – reload configuration from disk
 
 If `admin_password_hash` is set in `config.yaml`, Basic Auth credentials are
 required to access these routes.

--- a/tasks.yml
+++ b/tasks.yml
@@ -514,7 +514,7 @@ PHASE_T_BACKLOG:
     desc: Provide a mechanism to trigger ConfigManager reloads without using the admin panel.
     tags: [core, architecture]
     priority: P3
-    status: pending
+    status: done
 
   - id: 104
     title: Clarify or Remove comfyui-workflow.json

--- a/web_admin.py
+++ b/web_admin.py
@@ -54,6 +54,16 @@ class WebAdmin:
             self.config.reload()
             return jsonify({"status": "ok"})
 
+        @self.app.post("/reload")
+        def reload_config() -> Any:
+            if not self._auth():
+                abort(401)
+            try:
+                self.config.reload()
+                return jsonify({"status": "ok"})
+            except Exception as exc:  # noqa: BLE001 - runtime
+                return jsonify({"status": "error", "error": str(exc)}), 500
+
     # ------------------------------------------------------------------
     # Control methods
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- support POST /reload in `WebAdmin`
- document new admin API endpoint
- mark task 103 completed

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686bb6c6c654832abee8fe06ad4ebeed