### PR TITLE
Add docs image decoding helper

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install mkdocs mkdocs-material
+      - run: python scripts/decode_images.py
       - run: mkdocs build --strict
       - uses: lycheeverse/lychee-action@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,16 @@ pytest
 Optional extras such as **PyQt6** and **mediapipe** are mocked in the test
 suite, so they do not need to be installed.
 
+## Building Docs
+
+The documentation is generated with **MkDocs**. Restore the image assets and
+serve the site locally with:
+
+```bash
+python scripts/decode_images.py
+mkdocs serve
+```
+
 ## Code Style
 - Follow [PEP8](https://peps.python.org/pep-0008/) and type-hint all public APIs.
 - Use Google-style docstrings.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ b - blended morph
 ## Demo
 
 ![Demo GIF](docs/images/demo.gif)
-(If the image fails to load, run `python scripts/capture_screenshots.py` to generate it.)
+(If the image fails to load, run `python scripts/decode_images.py` to restore it or
+`python scripts/capture_screenshots.py` to regenerate.)
 
 To try the application without a webcam, place a `demo.mp4` file or a folder of
 images inside the `data/` directory and run with `--demo`.
@@ -146,5 +147,15 @@ The application logs average FPS and frame latency every few seconds. Adjust
 emitted.
 
 ![Admin Controls](docs/images/admin_controls.png)
-(Generate with `python scripts/capture_screenshots.py` if missing.)
+(If the image is missing, run `python scripts/decode_images.py` or
+`python scripts/capture_screenshots.py`.)
+
+## Building the Documentation
+
+The docs site is built with **MkDocs**. To preview it locally:
+
+```bash
+python scripts/decode_images.py  # restore PNG/GIF assets
+mkdocs serve
+```
 

--- a/scripts/decode_images.py
+++ b/scripts/decode_images.py
@@ -1,0 +1,18 @@
+import base64
+from pathlib import Path
+
+
+def decode_images(image_dir: Path) -> None:
+    for b64_path in image_dir.glob('*.b64'):
+        out_path = b64_path.with_suffix('')
+        data = base64.b64decode(b64_path.read_bytes())
+        out_path.write_bytes(data)
+        print(f"Decoded {b64_path} -> {out_path}")
+
+
+def main() -> None:
+    decode_images(Path('docs/images'))
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks.yml
+++ b/tasks.yml
@@ -620,3 +620,10 @@ PHASE_T_BACKLOG:
     tags: [monitoring, performance]
     priority: P3
     status: done
+
+  - id: 212
+    title: Restore docs images from base64
+    desc: Add `scripts/decode_images.py` to regenerate PNG/GIF assets for MkDocs.
+    tags: [docs, tooling]
+    priority: P5
+    status: done


### PR DESCRIPTION
## Summary
- add scripts/decode_images.py to restore PNG/GIF assets
- document image decoding in README and CONTRIBUTING
- run the decoding step in the docs workflow
- track the new helper in tasks.yml

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q` *(fails: ImportError libEGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_686bbd480d3c832aabbdb678c2c59e84