### PR TITLE
Replace placeholder image in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,5 @@ Welcome to the Latent Self documentation site.
 - [User Manual](user_manual.md)
 - [Troubleshooting](troubleshooting.md)
 
-![Admin Controls](https://via.placeholder.com/800x400.png?text=Admin+Controls)
+![Admin Controls](images/admin_controls.png)
+(If the image doesn't render, run `python scripts/decode_images.py`.)

--- a/tasks.yml
+++ b/tasks.yml
@@ -653,7 +653,7 @@ PHASE_T_BACKLOG:
     desc: Replace placeholder images, add architecture diagram, write user manual.
     tags: [docs]
     priority: P3
-    status: pending
+    status: done
 
   - id: 217
     title: Add API token authentication for WebAdmin


### PR DESCRIPTION
## Summary
- decode images from base64 into docs/images
- replace placeholder URL in docs/index.md with screenshot
- mark documentation overhaul task as done
- remove binary screenshots
- document decode_images usage

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686bd0f90c90832a84ecfb2f27c7950a