### PR TITLE
docs: use lock file for installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Latent Self is an interactive art installation that uses a webcam to capture a u
     ```
 2.  Install the dependencies:
     ```bash
-    pip install -r requirements.txt
+    pip install -r requirements.lock
     ```
 3.  Download the model weights (see below).
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -16,7 +16,7 @@ This guide walks you through installing Latent Self, adjusting its configuration
    ```
 3. Install the Python dependencies:
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements.lock
    ```
 4. Download the required model weights (StyleGAN generator, e4e encoder and `latent_directions.npz`) and place them inside the `models/` directory.
 5. (Optional) Build a standalone executable with PyInstaller:

--- a/tasks.yml
+++ b/tasks.yml
@@ -669,6 +669,13 @@ PHASE_T_BACKLOG:
   priority: P1
   status: done
 
+- id: DEPS-1
+  title: Modernize Dependencies and Verify Environment
+  desc: Update all project dependencies to the latest stable versions and regenerate the lock file.
+  tags: [build, deps]
+  priority: P2
+  status: done
+
 - id: 1002
   title: Code Cleanup and Final Refactoring
   desc: Perform a deep-dive code review to identify and address any remaining code smells, inconsistencies, or areas for minor refactoring.


### PR DESCRIPTION
## Summary
- instruct devs to use requirements.lock
- document lock file usage in user_manual
- track dependency work in tasks.yml

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_686cf219bb7c832abee83f291ee7e94e