### PR TITLE
Add docs publishing workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,19 @@
 name: Docs
 
 on:
+  push:
+    branches: [main]
   pull_request:
     paths:
       - 'docs/**'
       - '**.md'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
@@ -18,7 +25,22 @@ jobs:
           python-version: '3.11'
       - run: pip install mkdocs mkdocs-material
       - run: python scripts/decode_images.py
-      - run: mkdocs build --strict
+      - run: mkdocs build --strict --site-dir site
       - uses: lycheeverse/lychee-action@v1
         with:
           args: '--no-progress README.md CONTRIBUTING.md CHANGELOG.md docs/**/*.md'
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+    steps:
+      - id: deploy-pages
+        uses: actions/deploy-pages@v1
+

--- a/tasks.yml
+++ b/tasks.yml
@@ -693,7 +693,7 @@ PHASE_U_DOC_NETFLIX:
     desc: Integrate docs into version control and CI/CD.
     tags: [workflow, docs]
     priority: P2
-    status: pending
+    status: done
   - id: DOC-005
     title: Automate API Documentation Generation
     desc: Auto-generate API references from code annotations.


### PR DESCRIPTION
## Summary
- build docs on pushes to `main`
- deploy site with GitHub Pages
- mark DOC-004 as done

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686e2220cb80832aa5472df3500ed034