### PR TITLE
Add primary information needs to developer personas

### DIFF
--- a/docs/personas/backend_specialist.md
+++ b/docs/personas/backend_specialist.md
@@ -12,3 +12,8 @@ An experienced developer focused on server-side features and integrations.
 - Documentation sometimes assumes frontend knowledge.
 - Hard to trace configuration defaults across environments.
 - Limited examples of advanced backend workflows.
+
+## Primary Information Needs
+- Consolidated API reference with request/response examples.
+- Mapping of config files and environment variables.
+- Deployment and monitoring playbooks for backend services.

--- a/docs/personas/data_scientist.md
+++ b/docs/personas/data_scientist.md
@@ -12,3 +12,9 @@ A researcher exploring machine learning models integrated with the project.
 - Build environment differences cause reproducibility issues.
 - Sparse examples on customizing inference code.
 - Model versioning guidelines are unclear.
+
+## Primary Information Needs
+- Location of curated datasets and data dictionaries.
+- Steps for training and evaluating new models.
+- Examples for integrating models into the pipeline.
+- Reproducible environment setup and dependency management.

--- a/docs/personas/frontend_developer.md
+++ b/docs/personas/frontend_developer.md
@@ -12,3 +12,9 @@ A developer concentrating on the UI and user experience aspects of the project.
 - Sparse documentation on UI architecture.
 - Unsure where to propose design changes.
 - Mixed use of frontend frameworks in examples.
+
+## Primary Information Needs
+- Style guide and component library documentation.
+- Build and test toolchain instructions.
+- Sample API calls and data contracts.
+- Accessibility and design review guidelines.

--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -1,6 +1,6 @@
 # Developer Personas
 
-The following personas capture common perspectives among our engineering teams. Content templates may link to these profiles to clarify the intended audience.
+The following personas capture common perspectives among our engineering teams. Each profile outlines goals, pain points and the primary information these developers search for. Content templates may link to these profiles to clarify the intended audience.
 
 - [New Hire Developer](new_hire.md)
 - [Backend Specialist](backend_specialist.md)

--- a/docs/personas/new_hire.md
+++ b/docs/personas/new_hire.md
@@ -12,3 +12,9 @@ A developer who recently joined the organization and is unfamiliar with the proj
 - Overwhelmed by existing codebase.
 - Difficulty locating authoritative documentation.
 - Unsure which tools and scripts are actively maintained.
+
+## Primary Information Needs
+- Step-by-step environment setup and onboarding guides.
+- Architectural overview diagrams that explain component roles.
+- Central index of recommended scripts and utilities.
+- Clear contacts or channels for getting help during ramp-up.

--- a/docs/personas/sre.md
+++ b/docs/personas/sre.md
@@ -12,3 +12,9 @@ Engineer responsible for system stability and monitoring.
 - Monitoring configuration scattered across docs.
 - Limited troubleshooting scenarios.
 - Inconsistent terminology around services and modules.
+
+## Primary Information Needs
+- Architecture diagrams showing service interactions.
+- Standard operating procedures for deploys and rollbacks.
+- Links to dashboards and alert definitions.
+- Contact list for incident escalation.


### PR DESCRIPTION
## Summary
- expand developer persona docs with primary information needs
- mention new section on the personas index

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686e391af208832ab898a5357cdc10a7