### PR TITLE
Add docs style guide and templates

### DIFF
--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -1,0 +1,30 @@
+# Documentation Style Guide
+
+This guide defines the tone and formatting conventions for all project documentation.
+Follow these guidelines when creating or updating pages.
+
+## Tone and Voice
+- Write in a friendly, professional manner.
+- Speak directly to the reader using **you**.
+- Use active voice and keep sentences short.
+- Explain the reasoning behind steps and decisions.
+- Avoid unexplained jargon; define terms when first introduced.
+
+## Formatting
+- Author files in Markdown (`.md`).
+- Begin each page with a level 1 heading.
+- Use level 2 headings for major sections.
+- Include a `Context/Why` section after the summary to set the stage.
+- Keep line length under 120 characters where practical.
+- Use fenced code blocks with language identifiers.
+- Link to local documents using relative paths.
+
+## Document Templates
+Templates for common document types live in `docs/templates/`.
+Each template contains placeholders, including a **Context/Why** section.
+
+- **Tutorial** – step-by-step instructions to achieve a task.
+- **Reference** – factual descriptions of commands, APIs or configuration.
+- **Explanation** – background concepts or design reasoning.
+
+Use these templates as a starting point for new documentation.

--- a/docs/templates/explanation_template.md
+++ b/docs/templates/explanation_template.md
@@ -1,4 +1,4 @@
-# Tutorial Template
+# Explanation Template
 
 <!-- Target Personas:
 - [New Hire Developer](../personas/new_hire.md)
@@ -9,18 +9,13 @@
 -->
 
 ## Summary
-Briefly describe what the reader will accomplish.
+Introduce the concept or design being explained.
 
 ## Context/Why
-Explain the motivation or background for this tutorial.
+Describe the background and reasoning behind this topic.
 
-## Prerequisites
-List required tools, knowledge, or environment setup.
-
-## Steps
-1. First step explanation.
-2. Second step explanation.
-3. Continue as needed.
+## Details
+Provide in-depth explanation. Use subsections as needed.
 
 ## Additional Resources
 Link to related documentation or external references.

--- a/docs/templates/reference_template.md
+++ b/docs/templates/reference_template.md
@@ -1,4 +1,4 @@
-# Tutorial Template
+# Reference Template
 
 <!-- Target Personas:
 - [New Hire Developer](../personas/new_hire.md)
@@ -9,18 +9,16 @@
 -->
 
 ## Summary
-Briefly describe what the reader will accomplish.
+Briefly describe what this reference covers.
 
 ## Context/Why
-Explain the motivation or background for this tutorial.
+Explain when someone would use this reference and why it matters.
 
-## Prerequisites
-List required tools, knowledge, or environment setup.
+## Parameters
+List key parameters, flags, or options.
 
-## Steps
-1. First step explanation.
-2. Second step explanation.
-3. Continue as needed.
+## Usage
+Provide example usage or code samples.
 
 ## Additional Resources
 Link to related documentation or external references.

--- a/tasks.yml
+++ b/tasks.yml
@@ -711,7 +711,7 @@ PHASE_U_DOC_NETFLIX:
     desc: Provide a style guide and templates emphasising the "why".
     tags: [content, docs]
     priority: P2
-    status: pending
+    status: done
   - id: DOC-007
     title: Audit and Migrate Existing Documentation
     desc: Migrate valuable legacy docs to the new portal.


### PR DESCRIPTION
## Summary
- create `docs/style_guide.md` describing tone and formatting
- update tutorial template and add reference & explanation templates
- mark DOC-006 as done in `tasks.yml`

## Testing
- `python -m py_compile latent_self.py ui/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e4af94c50832a8fb5ff477531e6ec