### PR TITLE
Add inventory and setup doc for migration

### DIFF
--- a/docs/legacy_doc_inventory.md
+++ b/docs/legacy_doc_inventory.md
@@ -1,0 +1,16 @@
+# Legacy Documentation Inventory
+
+This page tracks our review of documentation sources from Confluence, Google Docs, and various wiki spaces.
+
+## Context/Why
+
+We want a single portal for accurate, up‑to‑date content. Auditing legacy docs helps us decide what to migrate, archive, or delete so you always find reliable information.
+
+| Title | Source | Last Updated | Owner | Decision |
+|-------|--------|--------------|-------|----------|
+| Setup Guide | Confluence | 2023‑05‑10 | Alice | Migrate |
+| Troubleshooting FAQ | Google Docs | 2022‑11‑04 | Bob | Migrate |
+| Release Notes 2019 | Wiki | 2019‑12‑30 | Carol | Archive |
+| Old Style Guide | Confluence | 2018‑07‑15 | Dave | Delete |
+| Integration API Draft | Google Docs | 2020‑03‑01 | Eve | Archive |
+

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -1,0 +1,26 @@
+# Setup Guide
+
+Follow these steps to get a development environment running quickly.
+
+## Context/Why
+
+You need a clear path to try the project yourself without digging through old docs.
+
+1. Clone the repository.
+   ```bash
+   git clone https://github.com/your-username/latent-self.git
+   cd latent-self
+   ```
+2. Create a Python 3.11 virtual environment and activate it.
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Install dependencies from the lock file.
+   ```bash
+   pip install -r requirements.lock
+   ```
+4. Run the application.
+   ```bash
+   python latent_self.py
+   ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,5 +10,7 @@ nav:
   - Release Process: release.md
   - Documentation Strategy: documentation_strategy.md
   - Docs as Code: docs_as_code.md
+  - Legacy Doc Inventory: legacy_doc_inventory.md
+  - Setup Guide: setup_guide.md
 
 docs_dir: docs


### PR DESCRIPTION
## Summary
- add a Legacy Documentation Inventory listing Confluence, Google Doc, and wiki sources
- create a Setup Guide showing how to start the project
- include the new pages in mkdocs navigation

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686e4bfd3438832aa0f9646c0e640264