### PR TITLE
Add Plausible analytics

### DIFF
--- a/docs/documentation_strategy.md
+++ b/docs/documentation_strategy.md
@@ -18,6 +18,7 @@ feedback and improvement proposals are routed through this role.
 - Time to first successful installation
 - Search success rate in the portal
 - Percentage of pull requests with accompanying docs
+- Page views and search queries tracked via Plausible
 
 A small dashboard summarising these metrics is published in the portal.
 

--- a/docs/js/plausible.js
+++ b/docs/js/plausible.js
@@ -1,0 +1,14 @@
+// Track search queries using Plausible
+if (window.plausible) {
+  document.addEventListener('DOMContentLoaded', function () {
+    var form = document.querySelector('form.md-search__form');
+    if (form) {
+      form.addEventListener('submit', function () {
+        var input = document.querySelector('input.md-search__input');
+        if (input && input.value) {
+          plausible('Search', {props: {query: input.value}});
+        }
+      });
+    }
+  });
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,3 +14,10 @@ nav:
   - Setup Guide: setup_guide.md
 
 docs_dir: docs
+extra:
+  analytics:
+    provider: plausible
+    domain: example.com
+extra_javascript:
+  - https://plausible.io/js/script.js
+  - js/plausible.js

--- a/tasks.yml
+++ b/tasks.yml
@@ -758,3 +758,9 @@ PHASE_U_DOC_NETFLIX:
   tags: [build, ci]
   priority: P1
   status: done
+- id: DOCS-011
+  title: Integrate privacy-friendly analytics
+  desc: Add Plausible analytics snippet to MkDocs and track search events
+  tags: [docs, analytics]
+  priority: P2
+  status: done


### PR DESCRIPTION
## Summary
- add Plausible snippet to MkDocs config
- track search events in new `docs/js/plausible.js`
- note analytics in documentation strategy
- log task completion

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686e527f279c832a97ba9ea11aa44c05