### PR TITLE
Enable versioned MkDocs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,12 @@ python scripts/decode_images.py  # restore PNG/GIF assets
 mkdocs serve
 ```
 
+### Deploying Versioned Docs
+Tag your release and run:
+
+```bash
+scripts/deploy_docs.sh
+```
+This publishes the documentation for the tagged version and updates the
+`latest` and `stable` aliases using the `mike` plugin.
+

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,5 @@
+# Versioned Documentation
+
+This site uses the [mike](https://github.com/jimporter/mike) plugin to manage
+multiple versions. Use the version selector in the header to switch between
+the `latest` documentation and the `stable` release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,9 @@
 site_name: Latent Self
 theme:
   name: material
+plugins:
+  - search
+  - mike
 nav:
   - Home: index.md
   - Architecture: architecture.puml
@@ -12,9 +15,12 @@ nav:
   - Docs as Code: docs_as_code.md
   - Legacy Doc Inventory: legacy_doc_inventory.md
   - Setup Guide: setup_guide.md
+  - Versioned Docs: versioning.md
 
 docs_dir: docs
 extra:
+  version:
+    provider: mike
   analytics:
     provider: plausible
     domain: example.com

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,3 +16,4 @@ onnxruntime==1.22.0
 sounddevice==0.5.2
 APScheduler==3.11.0
 python-osc==1.9.3
+mike==2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ onnxruntime        # optional ONNX inference
 sounddevice        # audio input for morphing
 APScheduler        # scheduled tasks
 python-osc         # Open Sound Control integration
+mike               # versioned documentation deployment

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Deploy versioned documentation using mike.
+set -euo pipefail
+
+VERSION=$(git describe --tags --abbrev=0)
+
+mike deploy --update-aliases "$VERSION" latest stable
+mike set-default stable

--- a/tasks.yml
+++ b/tasks.yml
@@ -764,3 +764,10 @@ PHASE_U_DOC_NETFLIX:
   tags: [docs, analytics]
   priority: P2
   status: done
+
+- id: DOCS-012
+  title: Enable versioned documentation
+  desc: Add mike plugin to build and publish docs per tag with a version selector
+  tags: [docs, versioning]
+  priority: P3
+  status: done


### PR DESCRIPTION
## Summary
- use the mike plugin for versioned docs
- provide version dropdown and nav link
- add script to deploy docs per tag
- document versioned docs workflow
- track new docs task

## Testing
- `python -m py_compile latent_self.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6882b88c832abc66b7961b588ca4