### PR TITLE
Add multi-repo indexing to docs portal

### DIFF
--- a/deploy/docs_portal/README.md
+++ b/deploy/docs_portal/README.md
@@ -8,11 +8,14 @@ Backstage was evaluated as a potential solution but was deemed too heavyweight f
 
 ## Usage
 
-Install the requirements and launch the site:
+Install the requirements and launch the site. The portal uses the
+`mkdocs-monorepo-plugin` to merge documentation from several
+repositories into a single searchable site:
 
 ```bash
-pip install mkdocs mkdocs-material
+pip install mkdocs mkdocs-material mkdocs-monorepo-plugin
 mkdocs serve -f mkdocs.yml
 ```
-
-The portal indexes all Markdown files under the repository `docs/` directory, providing full-text search across the documentation.
+The portal indexes Markdown files from this repository as well as
+`demo_portal/docs`, showcasing how multiple codebases can be combined
+into one portal with full-text search.

--- a/deploy/docs_portal/mkdocs.yml
+++ b/deploy/docs_portal/mkdocs.yml
@@ -3,6 +3,10 @@ theme:
   name: material
 plugins:
   - search
+  - monorepo:
+      docs_dirs:
+        - ../../docs
+        - ../../demo_portal/docs
 nav:
   - Home: index.md
   - Architecture: architecture.puml
@@ -12,5 +16,5 @@ nav:
   - Release Process: release.md
   - Documentation Strategy: documentation_strategy.md
 
-# Use project docs directory
+# Default docs directory (root repo)
 docs_dir: ../../docs

--- a/docs/portal_evaluation.md
+++ b/docs/portal_evaluation.md
@@ -20,3 +20,5 @@ This document outlines three approaches considered for centralising the project'
 ### Recommendation
 
 For the current scope, **MkDocs Material** strikes the best balance of simplicity and features. A proof‑of‑concept exists under `deploy/docs_portal`.
+The portal uses the `mkdocs-monorepo-plugin` so documentation from
+multiple repositories can be indexed in one searchable site.


### PR DESCRIPTION
## Summary
- update docs portal mkdocs config to use mkdocs-monorepo-plugin
- adjust portal README with instructions for the new plugin
- document final decision in portal evaluation doc

## Testing
- `python -m py_compile latent_self.py ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686e8122af84832abcbe301a41a6a99c